### PR TITLE
Provide context of the original exception to the new one

### DIFF
--- a/matter_persistence/decorators.py
+++ b/matter_persistence/decorators.py
@@ -19,84 +19,70 @@ class OperationOutcome(Enum):
     SUCCESS = "SUCCESS"
 
 
+def _exception_to_details(exception: BaseException) -> dict:
+    return {
+        "exception": exception,
+        "error_type": str(exception),
+        "error_message": type(exception).__name__,
+    }
+
+
 def retry_if_failed(func, delays=(0, 1, 5)):
     @wraps(func)
     async def async_wrapper(*args, **kwargs):
         operation_outcome = OperationOutcome.SUCCESS  # assume success
+        last_exception: Exception | None = None
         for delay in itertools.chain(delays, [None]):
             try:
                 result = await func(*args, **kwargs)
-
             except OperationalError as exc:
                 operation_outcome = OperationOutcome.SQL_ERROR
-                error_message = str(exc)
-                error_type = type(exc).__name__
                 needs_retry = True
-                detail = {
-                    "exception": exc,
-                    "error_type": error_type,
-                    "error_message": error_message,
-                }
                 new_exc = DatabaseError(
-                    description=f"Unable to perform database operation: {error_message}",
-                    detail=detail,
+                    description=f"Unable to perform database operation: {type(exc).__name__}",
+                    detail=_exception_to_details(exc),
                 )
-
+                last_exception = exc
             except IntegrityError as exc:
                 operation_outcome = OperationOutcome.SQL_ERROR
-                error_message = str(exc.orig)
-                error_type = type(exc).__name__
                 needs_retry = False
-                detail = {
-                    "exception": exc,
-                    "error_type": error_type,
-                    "error_message": error_message,
-                }
                 new_exc = DatabaseIntegrityError(
-                    description=f"Violation of rules or conditions: {error_message}",
-                    detail=detail,
+                    description=f"Violation of rules or conditions: {type(exc).__name__}",
+                    detail=_exception_to_details(exc),
                 )
-
+                last_exception = exc
             except ConnectionError as exc:
                 operation_outcome = OperationOutcome.CACHE_ERROR
-                error_message = str(exc)
-                error_type = type(exc).__name__
                 needs_retry = True
-                detail = {
-                    "exception": exc,
-                    "error_type": error_type,
-                    "error_message": error_message,
-                }
                 new_exc = CacheServerError(
-                    description=f"Unable to connect to Redis: {error_message}",
-                    detail=detail,
+                    description=f"Unable to connect to Redis: {type(exc).__name__}",
+                    detail=_exception_to_details(exc),
                 )
-
+                last_exception = exc
             except TimeoutError as exc:
                 operation_outcome = OperationOutcome.CACHE_ERROR
-                error_message = str(exc)
-                error_type = type(exc).__name__
                 needs_retry = False
-                detail = {
-                    "exception": exc,
-                    "error_type": error_type,
-                    "error_message": error_message,
-                }
                 new_exc = CacheServerError(
-                    description=f"Redis operation timed out: {error_message}",
-                    detail=detail,
+                    description=f"Redis operation timed out: {type(exc).__name__}",
+                    detail=_exception_to_details(exc),
                 )
-
+                last_exception = exc
             else:
                 needs_retry = False
+                new_exc = None
 
             if not needs_retry or delay is None:
-                if operation_outcome in [OperationOutcome.CACHE_ERROR, OperationOutcome.SQL_ERROR]:
-                    raise new_exc
+                if (
+                    operation_outcome in [OperationOutcome.CACHE_ERROR, OperationOutcome.SQL_ERROR]
+                    and new_exc is not None
+                ):
+                    raise new_exc from last_exception
                 return result
             else:
                 storage = "database" if operation_outcome == OperationOutcome.SQL_ERROR else "cache"
-                logging.warning(f"Unable to connect to {storage} due to {error_type}. Retrying in {delay} seconds...")
+                logging.warning(
+                    f"Unable to connect to {storage} due to {type(last_exception)}. Retrying in {delay} seconds...",
+                )
                 sleep(delay)
 
     return async_wrapper


### PR DESCRIPTION
The original exception needs to be preserved in the traceback, to allow for better debugging.