### PR TITLE
Add an option to use the given key as-is

### DIFF
--- a/tests/redis/conftest.py
+++ b/tests/redis/conftest.py
@@ -23,7 +23,7 @@ TEST_REDIS_PASSWORD = "VerySecretPassword!"
 # https://pytest-asyncio.readthedocs.io/en/latest/how-to-guides/run_session_tests_in_same_loop.html
 def pytest_collection_modifyitems(items):
     pytest_asyncio_tests = (item for item in items if is_async_test(item))
-    session_scope_marker = pytest.mark.asyncio(scope="session")
+    session_scope_marker = pytest.mark.asyncio(loop_scope="session")
     for async_test in pytest_asyncio_tests:
         async_test.add_marker(session_scope_marker, append=False)
 


### PR DESCRIPTION
This is required when we're dealing with data cached in a different way than through the CacheManager.