### PR TITLE
Support sequences of objects for save & get many with keys

### DIFF
--- a/matter_persistence/redis/manager.py
+++ b/matter_persistence/redis/manager.py
@@ -255,9 +255,24 @@ class CacheManager:
 
     async def get_many_with_keys(
         self, keys: Sequence[str], object_class: type[Model] | None = None
-    ) -> dict[str, bytes | list[bytes] | Model | list[Model] | None]:
+    ) -> dict[str, bytes | Model | list[Model] | None]:
+        """
+        Gets multiple values from the cache.
+
+        If object_class is specified, tries to deserialise the values into the given class. A list of values in the cache
+        for a single key is also supported. Values for all keys need to be of the same class.
+
+        The resulting dictionary values can contain:
+        - an object or a list of objects (if object_class is given)
+        - a raw bytes value (if object_class isn't given)
+        - None, if the key doesn't exist in cache
+
+        :param keys: which keys to get from the cache
+        :param object_class: used in deserialisation of cached values
+        :return: a dictionary, mapping the original set of keys to the corresponding values from the cache
+        """
         object_name = object_class.__name__ if object_class else None
-        return_set: dict[str, bytes | list[bytes] | Model | list[Model] | None] = {}
+        return_set: dict[str, bytes | Model | list[Model] | None] = {}
         async with self.__get_cache_client(for_writing=False) as cache_client:
             processed_input = {
                 CacheHelper.create_basic_hash_key(original_key, object_name): original_key for original_key in keys

--- a/tests/redis/test_manager.py
+++ b/tests/redis/test_manager.py
@@ -95,9 +95,9 @@ async def test_cache_manager_save_and_get_many_objects_converts_tuples_to_lists(
 async def test_cache_manager_save_and_get_many_raw_values_with_keys_success(cache_manager: CacheManager) -> None:
     test_input = {f"key_{i}": f"test_value_{i}" for i in range(10)}
     await cache_manager.save_many_with_keys(test_input, None, 100)
-    response: dict[
-        str, bytes | list[bytes] | BaseModel | list[BaseModel] | None
-    ] = await cache_manager.get_many_with_keys(list(test_input.keys()), None)
+    response: dict[str, bytes | BaseModel | list[BaseModel] | None] = await cache_manager.get_many_with_keys(
+        list(test_input.keys()), None
+    )
     for key, value in response.items():
         assert isinstance(value, bytes)
         assert test_input[key] == value.decode()


### PR DESCRIPTION
If object_class is given alongside a sequence of objects for a single key, we can use a TypeAdapter to [de]serialise values.
